### PR TITLE
Feature: continue doc comment on RETURN

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "Other"
     ],
     "activationEvents": [
+        "onLanguage:COBOL",
         "onCommand:cobolplugin.move2pd",
         "onCommand:cobolplugin.move2ws",
         "onCommand:cobolplugin.move2dd",
@@ -97,6 +98,7 @@
         "configurationDefaults": {
             "[COBOL]": {
                 "files.autoGuessEncoding": true,
+                "editor.formatOnType": true,
                 "editor.rulers": [6, 7, 72],
                 "editor.detectIndentation": false,
                 "editor.wordSeparators": "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/?"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { commands, ExtensionContext } from 'vscode';
 import * as cobolProgram from './cobolprogram';
 import * as tabstopper from './tabstopper';
 import * as opencopybook from './opencopybook';
+import { DocComment } from './formatting/DocComment';
 
 export function activate(context: ExtensionContext) {
     var move2pdCommand = commands.registerCommand('cobolplugin.move2pd', function () {
@@ -48,6 +49,8 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(unTabCommand);
     context.subscriptions.push(openCopyBookFileCommand);
     context.subscriptions.push(openPreviousFileCommand);
+
+    context.subscriptions.push(DocComment.register());
 }
 
 export function deactivate() {

--- a/src/formatting/DocComment.ts
+++ b/src/formatting/DocComment.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+import { CancellationToken, FormattingOptions, languages, TextDocument, TextEdit, Position, ProviderResult } from "vscode";
+
+export class DocComment {
+    static register() {
+        // Insert *>> when RETURN is pressed
+        return languages.registerOnTypeFormattingEditProvider({ language: 'COBOL' }, {
+            provideOnTypeFormattingEdits(document: TextDocument, position: Position, ch: string, options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]> {
+                const line = document.lineAt(position.line - 1);
+                if (line && line.text.trim().startsWith("*>>")) {
+                    return [
+                        TextEdit.insert(position, "*>> ")
+                    ]
+                } else {
+                    return []
+                }
+            }
+        }, '\n');
+    }
+}


### PR DESCRIPTION
This adds `*>>` to the new line that is inserted if you press RETURN on an existing doc-comment line.

I will rebase when #12 is merged.