### PR TITLE
Feature: go to definition for copybooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,15 +22,14 @@
         "Other"
     ],
     "activationEvents": [
+        "onLanguage:COBOL",
         "onCommand:cobolplugin.move2pd",
         "onCommand:cobolplugin.move2ws",
         "onCommand:cobolplugin.move2dd",
         "onCommand:cobolplugin.move2anyforward",
         "onCommand:cobolplugin.move2anybackwards",
         "onCommand:cobolplugin.tab",
-        "onCommand:cobolplugin.revtab",
-        "onCommand:cobolplugin.openCopyBookFile",
-        "onCommand:cobolplugin.openPreviousFile"
+        "onCommand:cobolplugin.revtab"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -223,14 +222,6 @@
             {
                 "command": "cobolplugin.revtab",
                 "title": "Remove a tab"
-            },
-            {
-                "command": "cobolplugin.openCopyBookFile",
-                "title": "Move to CopyBook"
-            },
-            {
-                "command": "cobolplugin.openPreviousFile",
-                "title": "Move back to previous file"
             }
         ],
         "menus": {
@@ -257,16 +248,6 @@
                 },
                 {
                     "command": "cobolplugin.move2anybackwards",
-                    "group": "cobolplugin",
-                    "when": "editorTextFocus && editorLangId == COBOL"
-                },
-                {
-                    "command": "cobolplugin.openCopyBookFile",
-                    "group": "cobolplugin",
-                    "when": "editorTextFocus && editorLangId == COBOL"
-                },
-                {
-                    "command": "cobolplugin.openPreviousFile",
                     "group": "cobolplugin",
                     "when": "editorTextFocus && editorLangId == COBOL"
                 }
@@ -376,36 +357,6 @@
             {
                 "key": "shift+tab",
                 "command": "cobolplugin.revtab",
-                "when": "editorLangId == OpenCOBOL && !inSnippetMode"
-            },
-            {
-                "key": "alt+c",
-                "command": "cobolplugin.openCopyBookFile",
-                "when": "editorLangId == COBOL && !inSnippetMode"
-            },
-            {
-                "key": "shift+alt+c",
-                "command": "cobolplugin.openPreviousFile",
-                "when": "editorLangId == COBOL && !inSnippetMode"
-            },
-            {
-                "key": "alt+c",
-                "command": "cobolplugin.openCopyBookFile",
-                "when": "editorLangId == ACUCOBOL && !inSnippetMode"
-            },
-            {
-                "key": "shift+alt+c",
-                "command": "cobolplugin.openPreviousFile",
-                "when": "editorLangId == ACUCOBOL && !inSnippetMode"
-            },
-            {
-                "key": "alt+c",
-                "command": "cobolplugin.openCopyBookFile",
-                "when": "editorLangId == OpenCOBOL && !inSnippetMode"
-            },
-            {
-                "key": "shift+alt+c",
-                "command": "cobolplugin.openPreviousFile",
                 "when": "editorLangId == OpenCOBOL && !inSnippetMode"
             }
         ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { commands, ExtensionContext } from 'vscode';
+import { commands, ExtensionContext, languages, TextDocument, Position, CancellationToken, ProviderResult, Definition } from 'vscode';
 import * as cobolProgram from './cobolprogram';
 import * as tabstopper from './tabstopper';
 import * as opencopybook from './opencopybook';
@@ -33,12 +33,6 @@ export function activate(context: ExtensionContext) {
         tabstopper.processTabKey(false);
     });
 
-    var openCopyBookFileCommand = commands.registerCommand('cobolplugin.openCopyBookFile', function () {
-        opencopybook.openCopyBookFile();
-    });
-    var openPreviousFileCommand = commands.registerCommand('cobolplugin.openPreviousFile', function () {
-        opencopybook.openPreviousFile();
-    });
     context.subscriptions.push(move2pdCommand);
     context.subscriptions.push(move2ddCommand);
     context.subscriptions.push(move2wsCommand);
@@ -46,8 +40,13 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(move2anybackwardsCommand);
     context.subscriptions.push(tabCommand);
     context.subscriptions.push(unTabCommand);
-    context.subscriptions.push(openCopyBookFileCommand);
-    context.subscriptions.push(openPreviousFileCommand);
+
+    const allCobolSelectors = ["COBOL", "ACUCOBOL", "OpenCOBOL"];
+    languages.registerDefinitionProvider(allCobolSelectors, {
+        provideDefinition(doc: TextDocument, pos: Position, ct: CancellationToken): ProviderResult<Definition> {
+            return opencopybook.provideDefinition(doc, pos, ct);
+        }
+    });
 }
 
 export function deactivate() {


### PR DESCRIPTION
This removes the open copybook and go to previous commands and instead uses a definition provider. This lets vscode handle the navigation and navigation history as well as allowing peek definition to work.

I will rebase when #12 is merged.