### PR TITLE
Add travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+sudo: false
+os:
+- linux
+language: node_js
+node_js:
+- 8
+
+env:
+  global:
+    secure: [VS_TOKEN=<Visual Studio Auth Token>]
+
+install:
+- npm install;
+
+script:
+- npm run compile
+- npm test --silent
+
+before_deploy:
+- npm install -g vsce;
+- vsce package;
+
+deploy:
+- provider: releases
+  api_key:
+    secure: [GITHUB_AUTH_TOKEN]
+  file_glob: true
+  file: "*.vsix"
+  skip_cleanup: true
+  on:
+    repo: spgennard/vscode_cobol
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux
+- provider: script
+  script: vsce publish -p $VS_TOKEN
+  skip_cleanup: true
+  on:
+    repo: spgennard/vscode_cobol
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux


### PR DESCRIPTION
Adds CI integration which builds and tests on each commit. It also packages and deploys the extension to GitHub and the vscode extension marketplace each time the repo is tagged.

You will need to replace the token placeholders in the script with secure strings which you can generate on Travis.

**Based on:**
- https://github.com/VSCodeVim/Vim/blob/master/.travis.yml
- http://jasonpoon.ca/2016/11/15/continuous-delivery-of-visual-studio-code-extensions/