### PR TITLE
Revert "Add new feature "back to last position""

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cobol",
-    "version": "5.1.0",
+    "version": "5.0.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
         "onCommand:cobolplugin.move2anybackwards",
         "onCommand:cobolplugin.tab",
         "onCommand:cobolplugin.revtab",
-        "onCommand:cobolplugin.back2lastPosition",
         "onCommand:cobolplugin.change_lang_to_acu",
         "onCommand:cobolplugin.change_lang_to_cobol",
         "onCommand:cobolplugin.change_lang_to_opemcobol",
@@ -421,10 +420,6 @@
         ],
         "commands": [
             {
-                "command": "cobolplugin.back2lastPosition",
-                "title": "Back to last position"
-            },
-            {
                 "command": "cobolplugin.move2pd",
                 "title": "Move to procedure division"
             },
@@ -464,11 +459,6 @@
         "menus": {
             "editor/context": [
                 {
-                    "command": "cobolplugin.back2lastPosition",
-                    "group": "cobolplugin",
-                    "when": "editorTextFocus && editorLangId == COBOL"
-                },
-                {
                     "command": "cobolplugin.move2dd",
                     "group": "cobolplugin",
                     "when": "editorTextFocus && editorLangId == COBOL"
@@ -496,26 +486,6 @@
             ]
         },
         "keybindings": [
-            {
-                "key": "alt+f12",
-                "command": "cobolplugin.back2lastPosition",
-                "when": "editorTextFocus && editorLangId == COBOL"
-            },
-            {
-                "key": "alt+f12",
-                "command": "cobolplugin.back2lastPosition",
-                "when": "editorTextFocus && editorLangId == ACUCOBOL"
-            },
-            {
-                "key": "alt+f12",
-                "command": "cobolplugin.back2lastPosition",
-                "when": "editorTextFocus && editorLangId == OpenCOBOL"
-            },
-            {
-                "key": "alt+f12",
-                "command": "cobolplugin.back2lastPosition",
-                "when": "editorTextFocus && editorLangId == GnuCOBOL"
-            },
             {
                 "key": "ctrl+alt+p",
                 "command": "cobolplugin.move2pd",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,9 +44,7 @@ export function activate(context: ExtensionContext) {
     var move2anybackwardsCommand = commands.registerCommand('cobolplugin.move2anybackwards', function () {
         cobolProgram.move2anybackwards();
     });
-    var back2lastPosition = commands.registerCommand('cobolplugin.back2lastPosition', function () {
-        sourcedefinitionprovider.back2lastPosition();
-    });
+
     var tabCommand = commands.registerCommand('cobolplugin.tab', function () {
         tabstopper.processTabKey(true);
     });
@@ -125,7 +123,7 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(tabCommand);
     context.subscriptions.push(unTabCommand);
     context.subscriptions.push(changeSourceFormat);
-    context.subscriptions.push(back2lastPosition);
+    
     context.subscriptions.push(changeLanguageToAcu);
     context.subscriptions.push(changeLanguageToCOBOL);
     context.subscriptions.push(changeLanguageToOpenCOBOL);

--- a/src/sourcedefinitionprovider.ts
+++ b/src/sourcedefinitionprovider.ts
@@ -1,9 +1,8 @@
-import { TextDocument, Definition, Position, CancellationToken, ProviderResult, Selection, TextEditorRevealType, window } from 'vscode';
+import { TextDocument, Definition, Position, CancellationToken, ProviderResult } from 'vscode';
 import * as vscode from 'vscode';
 import QuickCOBOLParse, { COBOLTokenStyle } from './cobolquickparse';
 import { VSCodeSourceHandler } from './VSCodeSourceHandler';
 
-let allPositions: number[] = new Array();
 
 function getFuzzyVariable(document: vscode.TextDocument, position: vscode.Position): vscode.Location | undefined {
     let wordRange = document.getWordRangeAtPosition(position, new RegExp("[a-zA-Z0-9_-]+"));
@@ -51,7 +50,6 @@ function getFuzzyVariable(document: vscode.TextDocument, position: vscode.Positi
 }
 
 function getSectionOrParaLocation(document: vscode.TextDocument, position: vscode.Position): vscode.Location | undefined {
-    allPositions.push(position.line);
     let wordRange = document.getWordRangeAtPosition(position, new RegExp('[0-9a-zA-Z][a-zA-Z0-9-_]*'));
     let word = wordRange ? document.getText(wordRange) : '';
     if (word === "") {
@@ -130,25 +128,6 @@ function getCallTarget(document: vscode.TextDocument, position: vscode.Position)
     return undefined;
 }
 
-export function back2lastPosition() {
-    if (allPositions.length > 0) {
-        let lastPosition = allPositions[allPositions.length - 1];
-        goToLine(lastPosition);
-        allPositions.pop();
-    }
-}
-
-function goToLine(line: number) {
-    if (window.activeTextEditor) {
-        let reviewType = TextEditorRevealType.InCenter;
-        if (line === window.activeTextEditor.selection.active.line) {
-            reviewType = TextEditorRevealType.InCenterIfOutsideViewport;
-        }
-        let newSe = new Selection(line, 0, line, 0);
-        window.activeTextEditor.selection = newSe;
-        window.activeTextEditor.revealRange(newSe, reviewType);
-    }
-}
 
 export function provideDefinition(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition> {
     let location: vscode.Location[] = [];


### PR DESCRIPTION
Reverts spgennard/vscode_cobol#72

I need to revert the changes because of the following observed issues:
 - line cache is not cleared when a new document is opened/closed
 - only the line is saved not the column
 - in getSectionOrParaLocation, the line is saved before we get a successful match

close but needs some more work.