### PR TITLE
Fix symbol operator token captures spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "onCommand:cobolplugin.change_source_format"
     ],
     "main": "./out/extension",
-    "license": "LICENSE IN LICENSE",
+    "license": "MIT",
     "homepage": "https://github.com/spgennard/vscode_cobol",
     "author": {
         "name": "Stephen Gennard",

--- a/syntaxes/COBOL.tmLanguage.json
+++ b/syntaxes/COBOL.tmLanguage.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "fileTypes": [
     "scbl",
     "cbl",
@@ -186,8 +187,7 @@
           "include": "source.sql"
         }
       ],
-      "end": "(?i:end\\-exec)",
-      "endCaptures": "string.quoted.cobol.sql"
+      "end": "(?i:end\\-exec)"
     },
     {
       "begin": "(?i:exec\\s+cics)",
@@ -208,8 +208,7 @@
           }
         }
       ],
-      "end": "(?i:end\\-exec)",
-      "endCaptures": "string.quoted.cobol.cics"
+      "end": "(?i:end\\-exec)"
     },
     {
       "begin": "(?i:exec\\s+sqlims)",
@@ -224,8 +223,7 @@
           "include": "source.sql"
         }
       ],
-      "end": "(?i:end\\-exec)",
-      "endCaptures": "string.quoted.cobol.sqlims"
+      "end": "(?i:end\\-exec)"
     },
     {
       "begin": "(?i:exec\\s+ado)",
@@ -240,8 +238,7 @@
           "include": "source.sql"
         }
       ],
-      "end": "(?i:end\\-exec)",
-      "endCaptures": "string.quoted.cobol.ado"
+      "end": "(?i:end\\-exec)"
     },
     {
       "begin": "(?i:exec\\s+html)",
@@ -252,8 +249,7 @@
           "include": "text.html.basic"
         }
       ],
-      "end": "(?i:end\\-exec)",
-      "endCaptures": "string.quoted.cobol.html"
+      "end": "(?i:end\\-exec)"
     },
     {
       "match": "(\")(CBL_.*)(\")",
@@ -402,7 +398,7 @@
       "name": "string.quoted.single.cobol"
     },
     {
-      "match": "(?<![-_])(?i:id\\s+division|identification\\s+division|identification|property-id|getter|setter|entry|function-id|end\\s+attribute|attribute|interface-id|indexer-id|factory|ctl|class-control|options|environment\\s+division|environment-name|environment-value|environment|configuration\\s+section|configuration|decimal-point\\s+is|decimal-point|console\\s+is|call-convention|special-names|cursor\\s+is|update|picture\\s+symbol|currency\\s+sign|currency|repository|input-output\\s+section|input-output|file\\s+section|file-control|select|optional|i-o-control|data\\s+division|working-storage\\s+section|working-storage|section|local-storage|linkage\\s+section|linkage|communication|report|screen\\s+section|object-storage|object\\s+section|class-object|fd|rd|cd|sd|printing|procedure\\s+division|procedure|references|debugging|end\\s+declaratives|declaratives|end\\s+static|end\\s+factory|end\\s+class-object|based-storage|size|font|national-edited|national)(?=\\s|\\.)",
+      "match": "(?<![-_])(?i:id\\s+division|identification\\s+division|identification|property-id|getter|setter|entry|function-id|end\\s+attribute|attribute|interface-id|indexer-id|factory|ctl|class-control|options|environment\\s+division|environment-name|environment-value|environment|configuration\\s+section|configuration|decimal-point\\s+is|decimal-point|console\\s+is|call-convention|special-names|cursor\\s+is|update|picture\\s+symbol|currency\\s+sign|currency|repository|input-output\\s+section|input-output|file\\s+section|file-control|select|optional|i-o-control|data\\s+division|working-storage\\s+section|working-storage|section|local-storage|linkage\\s+section|linkage|communication|report|screen\\s+section|object-storage|object\\s+section|class-object|fd|rd|cd|sd|printing|procedure\\s+division|procedure|references|debugging|end\\s+declaratives|declaratives|end\\s+static|end\\s+factory|end\\s+class-object|based-storage|size|font|national-edited|national)(?![0-9A-Za-z_-])",
       "name": "keyword.identifiers.cobol"
     },
     {
@@ -414,8 +410,7 @@
         "2": {
           "name": "entity.name.function.cobol"
         }
-      },
-      "end": "(\\.| |$)"
+      }
     },
     {
       "match": "(?<![-_])(?i:implements|inherits|constraints|constrain)(?=\\s|\\.)",
@@ -602,7 +597,7 @@
       "name": "storage.modifier.cobol"
     },
     {
-      "match": "\\s+(?i:=|<|>|<=|>=|<>|\\+|\\-|\\*|\\/|b-and|b-or|b-xor|b-exor|b-not|b-left|b-right|and|or|equals|equal|greater\\s+than|less\\s+than|greater)(?=\\s+|\\.|$)",
+      "match": "=|<|>|<=|>=|<>|\\+|\\-|\\*|\\/|(?<![-_])(?i:b-and|b-or|b-xor|b-exor|b-not|b-left|b-right|and|or|equals|equal|greater\\s+than|less\\s+than|greater)(?![0-9A-Za-z_-])",
       "name": "keyword.operator.cobol"
     },
     {
@@ -610,7 +605,7 @@
       "name": "keyword.verbs.cobol"
     },
     {
-      "match": "(?<![-_])(?i:not)(?=\\s+|\\.|$)",
+      "match": "(?<![-_])(?i:not)(?![0-9A-Za-z_-])",
       "name": "keyword.operator.cobol"
     },
     {


### PR DESCRIPTION
This allows the space characters to be used by other rules matching.

Also allows non-identifier characters following the SIZE keyword. Ex: `DELIMITED BY SIZE, ""`