### PR TITLE
Allow any non-identifier character after FALSE

### DIFF
--- a/syntaxes/COBOL.tmLanguage.json
+++ b/syntaxes/COBOL.tmLanguage.json
@@ -163,7 +163,7 @@
       "name": "constant.numeric.cobol"
     },
     {
-      "match": "(?<![-_])(?i:true|false|null|nulls)(?=\\s|\\.|\\)|$)",
+      "match": "(?<![-_])(?i:true|false|null|nulls)(?![0-9A-Za-z_-])",
       "name": "constant.language.cobol"
     },
     {


### PR DESCRIPTION
This is to catch `FALSE*>`