### PR TITLE
Recognize .bib files as COBOL code

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,9 @@
                         "CPY",
                         "SCR",
                         "cbl",
-                        "CBL"
+                        "CBL",
+                        "bib",
+                        "BIB"
                     ],
                     "description": "COBOL CopyBook Extensions"
                 },
@@ -311,7 +313,8 @@
                     ".src",
                     ".ss",
                     ".wks",
-                    ".pco"
+                    ".pco",
+                    ".bib"
                 ],
                 "configuration": "./cobol.configuration.json"
             },

--- a/syntaxes/COBOL.tmLanguage.json
+++ b/syntaxes/COBOL.tmLanguage.json
@@ -8,7 +8,8 @@
     "dds",
     "ss",
     "wks",
-    "pco"
+    "pco",
+    "bib"
   ],
   "name": "COBOL",
   "patterns": [


### PR DESCRIPTION
Some people uses .bib files with cobol code, mainly for secondary code or files definition.

This file, for example:
![.bib file](https://i.imgur.com/Z1yhNxO.png)