### PR TITLE
COPY variants

### DIFF
--- a/src/opencopybook.ts
+++ b/src/opencopybook.ts
@@ -50,8 +50,10 @@ function extractCopyBoolFilename(str: string) {
         let copyRegs: RegExp[] = [
             new RegExp(".*copy\\s*[\"'](.*)[\"'].*$", "i"),
             new RegExp(".*copy\\s*[\"'](.*)[\"']$", "i"),
-            new RegExp(".*copy\\s*[\"'](.*)[\"']\\replacing.*$", "i"),
-            new RegExp(".*copy\\s*(.*)\\sreplacing.*$", "i"),
+            new RegExp(".*copy\\s*[\"'](.*)[\"']\\s+suppress.*$", "i"),
+            new RegExp(".*copy\\s*(.*)\\s+suppress.*$", "i"),
+            new RegExp(".*copy\\s*[\"'](.*)[\"']\\s+replacing.*$", "i"),
+            new RegExp(".*copy\\s*(.*)\\s+replacing.*$", "i"),
             new RegExp(".*copy\\s*(.*)$", "i"),
             new RegExp(".*copy\\s*(.*)\\s.*$", "i"),
             new RegExp(".*copy\\s*(.*)\\.$", "i")


### PR DESCRIPTION
follow-up to cd66efc71b3336a245e64dc2b45fe480d8b966a3 #139 

* fixed a typo (missing "s" before replacing)
* allow multiple space characters before `REPLACING` phrase
* included `SUPPRESS` phrase

Question - Shouldn't

```
            new RegExp(".*copy\\s*[\"'](.*)[\"'].*$", "i"),
```

include every line after it that use `"` already? Is this intended?