### PR TITLE
Fix invalid regex on mfcobol-errformat2 problem matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1025,7 +1025,7 @@
             },
             {
                 "name": "mfcobol-errformat2",
-                "regexp": "^\\*+\\s+COBCH\\d+([a-zA-Z])\\s+([^:]+):\\s+(\\S*)\\((\\d+),(\\d+),.*\\)$",
+                "regexp": "^\\*+\\s+COBCH\\d+([a-zA-Z])\\s+([^:]+):\\s+(\\S*)\\((\\d+),(\\d+).*\\)$",
                 "severity": 1,
                 "message": 2,
                 "file": 3,


### PR DESCRIPTION
fixing https://github.com/spgennard/vscode_cobol/issues/146