### PR TITLE
fix mfcobol-errformat2-copybook-netx-sx matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1335,7 +1335,7 @@
             },
             {
                 "name": "mfcobol-errformat2-copybook-netx-sx",
-                "regexp": "^\\*+\\s+(COBCH\\d+)([USEWI])\\s+([^:]+):[^,]++(.*)\\((\\d+),(\\d+).*\\).*$",
+                "regexp": "^\\*+\\s+(COBCH\\d+)([USEWI])\\s+([^:]+):[^,]+,(.*)\\((\\d+),(\\d+).*\\).*$",
                 "code": 1,
                 "severity": 2,
                 "message": 3,

--- a/package.json
+++ b/package.json
@@ -1335,7 +1335,7 @@
             },
             {
                 "name": "mfcobol-errformat2-copybook-netx-sx",
-                "regexp": "^\\*+\\s+(COBCH\\d+)([USEWI])\\s+([^:]+):\\s+(.*)\\((\\d+),(\\d+).*\\).*$",
+                "regexp": "^\\*+\\s+(COBCH\\d+)([USEWI])\\s+([^:]+):[^,]++(.*)\\((\\d+),(\\d+).*\\).*$",
                 "code": 1,
                 "severity": 2,
                 "message": 3,


### PR DESCRIPTION
previously was identical to mfcobol-errformat2-netx-sx, missed the separator comma