### PR TITLE
recognize GnuCOBOL listings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -416,7 +416,8 @@ function flip_plaintext(doc: TextDocument) {
                 return;
             }
 
-            if (firstLine.startsWith("Pro*COBOL: Release")) {
+            if (firstLine.startsWith("GnuCOBOL ")
+             || firstLine.startsWith("Pro*COBOL: Release")) {
                 vscode.languages.setTextDocumentLanguage(doc, "COBOL_LISTFILE");
                 return;
             }


### PR DESCRIPTION
Following 4cfc966e36b5418ab22219596cba3064ca1cabb9 and the heading used in GnuCOBOL produced listings.
https://sourceforge.net/p/gnucobol/code/HEAD/tree/trunk/tests/testsuite.src/listings.at gives a sample (the V.R.P is a replaced version, it normally shows the version number instead).