### PR TITLE
Added support for the COBOL keyword CHAINING

### DIFF
--- a/src/keywords/cobolKeywords.ts
+++ b/src/keywords/cobolKeywords.ts
@@ -42,6 +42,7 @@ export const cobolKeywords: string[] = [
 	"cells",
 	"cf",
 	"ch",
+	"chaining",
 	"character",
 	"characters",
 	"class",

--- a/syntaxes/COBOL.tmLanguage.json
+++ b/syntaxes/COBOL.tmLanguage.json
@@ -536,7 +536,7 @@
       "name": "keyword.control.catch-exception.cobol"
     },
     {
-      "match": "(?<![-_])(?i:select|use|thru|varying|giving|remainder|tallying|through|until|execute|returning|using|yielding|\\+\\+include|copy|replace)(?=\\s)",
+      "match": "(?<![-_])(?i:select|use|thru|varying|giving|remainder|tallying|through|until|execute|returning|using|chaining|yielding|\\+\\+include|copy|replace)(?=\\s)",
       "name": "keyword.otherverbs.cobol"
     },
     {


### PR DESCRIPTION
Added support for the COBOL keyword `CHAINING`. The `CHAINING` verb immediately behind the `PROCEDURE DIVISION` declaration defines arguments that will be passed to a main program from the operating system.