### PR TITLE
Update bld_cobscanner.sh

### DIFF
--- a/bld_cobscanner.sh
+++ b/bld_cobscanner.sh
@@ -1,9 +1,7 @@
 set +e
 PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
 
-
 export PATH=$(pwd)/./node_modules/.bin:$PATH
-test ! -d cobscanner && mkdir cobscanner
 #browserify out/cobscanner.js --require n-readlines --outfile cobscanner/cobscanner.js
 cp ./out/cobscanner.js cobscanner/
 cp ./out/cobscannerdata.js cobscanner/

--- a/bld_cobscanner.sh
+++ b/bld_cobscanner.sh
@@ -15,7 +15,7 @@ cp ./out/filesourcehandler.js cobscanner/
 cp ./out/cobolglobalcache.js cobscanner/
 cp ./out/cobolsourcescanner.js cobscanner/
 cp -r ./out/keywords cobscanner/
-cp -r ./out/keywords cobscanner/
+
 cd cobscanner
 npm version --allow-same-version $PACKAGE_VERSION
 npm install


### PR DESCRIPTION
The testing and creation seems to be obsolete as there's a cobscanner directory with content in this repo and I'm not sure if the later npm command would work if the contained package-lock.json would not be in the repo.