### PR TITLE
Update for GnuCOBOL matchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1471,7 +1471,7 @@
             },
             {
                 "name": "opencobol-cobc",
-                "regexp": "^(.*):\\s(\\d+):.*(error|warning):(.*)$",
+                "regexp": "^(.*):\\s(\\d+): (error|warning):(.*)$",
                 "file": 1,
                 "line": 2,
                 "severity": 3,
@@ -1479,66 +1479,70 @@
             },
             {
                 "name": "opencobol-error-cobc",
-                "regexp": "^(.*):\\s(\\d+):.*([eE]rror|[fF]ehler|[eE]rrores|[eE]rrores):(.*)$",
+                "regexp": "^(.*):\\s(\\d+): ([eE]rror|[fF]ehler|[eE]rrores|[eE]rrores):(.*)$",
                 "file": 1,
                 "line": 2,
                 "message": 4
             },
             {
                 "name": "opencobol-warning-cobc",
-                "regexp": "^(.*):\\s(\\d+):.*([wW]arning|[wW]arnung|[aA]lerta):(.*)$",
+                "regexp": "^(.*):\\s(\\d+): ([wW]arning|[wW]arnung|[aA]lerta):(.*)$",
+                "file": 1,
+                "line": 2,
+                "message": 4
+            },
+            {
+                "name": "cobolit-cobc",
+                "regexp": "^(.*):(\\d+): ([eE]rror|[wW]arning):\\s+(.*)$",
+                "file": 1,
+                "line": 2,
+                "severity": 3,
+                "message": 4
+            },
+            {
+                "name": "cobolit-note-cobc",
+                "regexp": "^(.*):(\\d+): ([nN]ote:|[wW]arning: ->)\\s+(.*)$",
                 "file": 1,
                 "line": 2,
                 "message": 4
             },
             {
                 "name": "gnucobol-cobc",
-                "regexp": "^(.*):\\s(\\d+):.*([eE]rror|[wW]arning|[nN]ote):(.*)$",
+                "regexp": "^(.*): ?(\\d+): ([eE]rror|[wW]arning): ([^[]*)(\\[(.*)\\])?$",
                 "file": 1,
                 "line": 2,
                 "severity": 3,
-                "message": 4
+                "message": 4,
+                "code": 6
             },
             {
                 "name": "gnucobol3-cobc",
-                "regexp": "^(.*):(\\d+):\\s.*([eE]rror|[wW]arning|nN]ote):(.*)$",
+                "regexp": "^(.*): ?(\\d+): (error|warning): ([^[]*)(\\[(.*)\\])?$",
                 "file": 1,
                 "line": 2,
                 "severity": 3,
-                "message": 4
-            },
-            {
-                "name": "cobolit-cobc",
-                "regexp": "^(.*):(\\d+):\\s.*([eE]rror|[wW]arning):\\s+(.*)$",
-                "file": 1,
-                "line": 2,
-                "severity": 3,
-                "message": 4
+                "message": 4,
+                "code": 6
             },
             {
                 "name": "gnucobol-warning-cobc",
-                "regexp": "^(.*):(\\d+):\\s.*([wW]arning|[wW]arnung|[aA]lerta):(.*)$",
+                "regexp": "^(.*): ?(\\d+): ([wW]arning|[wW]arnung|[wW]aarschuwing|[aA]lerta|avertissement|упозорење): ([^[]*)(\\[(.*)\\])?$",
                 "file": 1,
                 "line": 2,
-                "message": 4
+                "message": 4,
+                "code": 6
             },
             {
                 "name": "gnucobol-error-cobc",
-                "regexp": "^(.*):(\\d+):\\s.*([eE]rror|[fF]ehler|[eE]rrores|[eE]rrores):(.*)$",
+                "regexp": "^(.*): ?(\\d+): *([eE]rror|[fF]ehler|[fF]out||[eE]rrores|[eE]rrores|erreur|грешка): ([^[]*)(\\[(.*)\\])?$",
                 "file": 1,
                 "line": 2,
-                "message": 4
-            },
-            {
-                "name": "cobolit-note-cobc",
-                "regexp": "^(.*):(\\d+):\\s.*([nN]ote:|[wW]arning: ->)\\s+(.*)$",
-                "file": 1,
-                "line": 2,
-                "message": 4
+                "message": 4,
+                "code": 6
             },
             {
                 "name": "gnucobol3-note-cobc",
-                "regexp": "^(.*):(\\d+):\\s.*([nN]ote|Anmerkung|[nN]ota): ([^[]*)(\\[(.*)\\])?$",
+                "regexp": "^(.*): ?(\\d+): ([nN]ote|Anmerkung|[nN]ota): ([^[]*)(\\[(.*)\\])?$",
                 "file": 1,
                 "line": 2,
                 "message": 4,

--- a/src/test/suite/co_gnucobol-error-cobc.txt
+++ b/src/test/suite/co_gnucobol-error-cobc.txt
@@ -1,2 +1,10 @@
+a.out:1: Error: Invalid indicator 'X' at column 7 OC1.1
+
+a.out: 1: Error: Invalid indicator 'X' at column 7 GC2.0beta
+
+a.out: 6: error: invalid indicator ' GC3.1
+a.out: 7: error: PROGRAM-ID header missing
+
 prog.cob:22: error: OPEN REVERSED is obsolete in GnuCOBOL
+prog.cob:18: error: OPEN REVERSED is obsolete in GnuCOBOL [-Werror=obsolete]
 prog.cob:22: errores: OPEN REVERSED is obsolete in GnuCOBOL


### PR DESCRIPTION
* added code attribute to all gc-matchers
* made all gc-matchers apply to old and new versions by using an optional space
* added Dutch, French and Serbian for GC
* replaced `\\s` by plain space and removed optional ignored values where they never occurred (OC, C*IT, GC)
* added samples for OC 1.1, GC2, GC3.1 format in the tests (match as expected in the testsuite)

Follow-up to 5b15c769d0bc3c7bd17646362c49a0b578150c01.