### PR TITLE
fixed typo leading to broken task definition

### DIFF
--- a/src/bldTaskProvider.ts
+++ b/src/bldTaskProvider.ts
@@ -51,7 +51,7 @@ export class BldScriptTaskProvider implements vscode.TaskProvider {
 		const envCOBDIR = process.env["COBDIR"];
 
 		if (envACUCOBOL !== undefined) {
-			matchers.push("$acucobol-warning-ccbll");
+			matchers.push("$acucobol-warning-ccbl");
 			matchers.push("$acucobol-ccbl");
 		}
 


### PR DESCRIPTION
Additional question: As the gnucobol extension has no ts source at all - can we add this here?