### PR TITLE
Fix BeginCaptures and EndCaptures grammar errors in the mfu grammar

### DIFF
--- a/syntaxes/mfu.tmLanguage.json
+++ b/syntaxes/mfu.tmLanguage.json
@@ -16,11 +16,11 @@
             "patterns": [
                 {
                     "begin": "#",
-                    "beginCaptures": [
-                        {
+                    "beginCaptures": {
+                        "1": {
                             "name": "punctuation.definition.comment.mfu"
                         }
-                    ],
+                    },
                     "end": "\\n",
                     "name": "comment.line.number-sign.mfu"
                 }
@@ -37,11 +37,11 @@
             "patterns": [
                 {
                     "begin": ";",
-                    "beginCaptures": [
-                        {
+                    "beginCaptures": {
+                        "1": {
                             "name": "punctuation.definition.comment.mfu"
                         }
-                    ],
+                    },
                     "end": "\\n",
                     "name": "comment.line.semicolon.mfu"
                 }
@@ -106,17 +106,17 @@
         },
         {
             "begin": "'",
-            "beginCaptures": [
-                {
+            "beginCaptures": {
+                "1": {
                     "name": "punctuation.definition.string.begin.mfu"
                 }
-            ],
+            },
             "end": "'",
-            "endCaptures": [
-                {
+            "endCaptures": {
+                "1": {
                     "name": "punctuation.definition.string.end.mfu"
                 }
-            ],
+            },
             "name": "string.quoted.single.mfu",
             "patterns": [
                 {
@@ -127,17 +127,17 @@
         },
         {
             "begin": "\"",
-            "beginCaptures": [
-                {
+            "beginCaptures": {
+                "1": {
                     "name": "punctuation.definition.string.begin.mfu"
                 }
-            ],
+            },
             "end": "\"",
-            "endCaptures": [
-                {
+            "endCaptures": {
+                "1": {
                     "name": "punctuation.definition.string.end.mfu"
                 }
-            ],
+            },
             "name": "string.quoted.double.mfu"
         },
         {


### PR DESCRIPTION
👋 I'm the lead maintainer of https://github.com/github/linguist which is used for language and syntax highlighting on GitHub.com.

We currently use https://bitbucket.org/bitlang/sublime_cobol for highlighting Cobol files. This repo is taking your grammars and converting them into the Sublime-compatible XML structure. 

Unfortunately, due to a few errors in the `mfu.tmLanguage.json` file added in https://github.com/spgennard/vscode_cobol/commit/0c46dbb89dc208497de3feb13c2ad14af410d9f0, our grammar compiler (which converts and validates all grammars into JSON that is loaded by our syntax highlighting service) has started detecting problems  with the grammar that ultimately stem from errors in the grammar here:

```
- Grammar conversion failed. File `syntaxes/mfu.tmLanguage.json` failed to parse: 6 error(s) decoding:

* 'Patterns[0].Patterns[0].BeginCaptures' expected a map, got 'slice'
* 'Patterns[1].Patterns[0].BeginCaptures' expected a map, got 'slice'
* 'Patterns[7].BeginCaptures' expected a map, got 'slice'
* 'Patterns[7].EndCaptures' expected a map, got 'slice'
* 'Patterns[8].BeginCaptures' expected a map, got 'slice'
* 'Patterns[8].EndCaptures' expected a map, got 'slice'
```

These are Go structures but essentially boil down to incorrect syntax in the JSON for the mentioned `BeginCaptures` and `EndCaptures` sections.

This PR addresses those issues.

I've not had the time to report this or submit a fix until now, so the Cobol grammars have not been updated for quite some time and I'd like to update them.

As an aside, whilst we don't currently use this repo for the syntax highlighting, if you're happy with it, I'm happy to switch to using this repo once this has been fixed, thus removing the middle man and allowing your changes to appear on GitHub.com sooner. No action will be needed from you as we'll automatically pull in the latest update every time we make a new release which is approximately once a month. The only action that may be needed from you is addressing any problems specific to this repo.

If you'd prefer not, that's fine. We'll keep relying on the intermediate repo.