### PR TITLE
pass word definition to EvaluatableExpressionProvider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -963,6 +963,15 @@ export async function activate(context: ExtensionContext): Promise<void> {
         context.subscriptions.push(languages.registerDocumentSymbolProvider(getAllCobolSelectors(), documentSymbolProvider));
     }
 
+	// override VS Code's default implementation of the debug hover by using document object's word position
+    // which uses the wordpattern (defined in cobol.configuration.json)
+    context.subscriptions.push(languages.registerEvaluatableExpressionProvider(getAllCobolSelectors(), {
+		provideEvaluatableExpression(document: vscode.TextDocument, position: vscode.Position): vscode.ProviderResult<vscode.EvaluatableExpression> {
+			const wordRange = document.getWordRangeAtPosition(position);
+			return wordRange ? new vscode.EvaluatableExpression(wordRange) : undefined;
+        }
+    }));
+
     const cobolProvider = new CobolSourceCompletionItemProvider(VSCOBOLConfiguration.get());
     const cobolProviderDisposible = languages.registerCompletionItemProvider(getAllCobolSelectors(), cobolProvider);
     context.subscriptions.push(cobolProviderDisposible);


### PR DESCRIPTION
The default implementation in vscode uses a traditional split:

```typescript
		// Match any character except a set of characters which often break interesting sub-expressions
		let expression: RegExp = /([^()\[\]{}<>\s+\-/%~#^;=|,`!]|\->)+/g;
```

But since vscode 1.43 there is a new [Debug hover API](https://code.visualstudio.com/updates/v1_43#_debugger-extension-api) to let language providers have something to say about what is an actual word that is (likely to be) resolved as an expression.

This PR using the existing word definition for this information and is therefore a much better variant than vscode's "then language provider does not tell me" fallback, as found in the [MockDebug](https://github.com/microsoft/vscode-mock-debug/blob/35e0a6c2bc69b0a1464b857ad1e6cb55ada11d87/src/activateMockDebug.ts#L98).
I think it would be reasonable to extend it by checking the result against the known COBOL tokens (like `END-DISPLAY`) [which is an actual interesting side case - this is a valid user defined word in cobol85 and likely ibm but not in nearly every other dialect], but I'm not sure how to "correctly" use this, so I leave this to a possible later change by someone else.