### PR TITLE
Don't decorate the sequence and comment areas by default.

### DIFF
--- a/src/margindecorations.ts
+++ b/src/margindecorations.ts
@@ -113,7 +113,7 @@ export class VSmargindecorations extends ColourTagHandler {
                 activeTextEditor.setDecorations(defaultTrailingSpacesDecoration, defaultDecorationOptions);
                 return;
         }
-        
+
 
         const maxLineLength = configHandler.editor_maxTokenizationLineLength;
         const maxLines = doc.lineCount;
@@ -177,10 +177,10 @@ export class VSmargindecorations extends ColourTagHandler {
                             }
                         }
                     }
-                }
 
-                if (useDefault) {
-                    defaultDecorationOptions.push(decoration);
+                    if (useDefault) {
+                        defaultDecorationOptions.push(decoration);
+                    }
                 }
             }
 
@@ -228,10 +228,10 @@ export class VSmargindecorations extends ColourTagHandler {
                             }
                         }
                     }
-                }
 
-                if (useDefault) {
-                    defaultDecorationOptions.push(decoration);
+                    if (useDefault) {
+                        defaultDecorationOptions.push(decoration);
+                    }
                 }
             }
         }


### PR DESCRIPTION
There should be a user-configurable option for this, and the existing enable_columns_tags seemed as good as any.

---

This allows my custom extension grammar to have syntax highlighting rules that aren't overridden by the decoration.