### PR TITLE
Update cobol.json: Minimum mainframe program [uppercase] snippet.

### DIFF
--- a/snippets/cobol.json
+++ b/snippets/cobol.json
@@ -266,7 +266,7 @@
 		"prefix": "IDENTIFICATION",
 		"body": [
 			"       IDENTIFICATION DIVISION.",
-			"       PROGRAM-ID. ${1:${1:${TM_FILENAME/(.*)\\..+$/$1/}}}.",
+			"       PROGRAM-ID. ${1:${TM_FILENAME/(.*)\\..+$/$1/}}.",
 			"       AUTHOR. $2.",
 			"       INSTALLATION.  ${3:where}.",
 			"       DATE-WRITTEN.  ${4:$CURRENT_DATE/$CURRENT_MONTH/$CURRENT_YEAR}.",


### PR DESCRIPTION
When running "Minimum mainframe program [uppercase] snippet, got the following error:

```
E5108: Error executing lua ...ker/start/LuaSnip/lua/luasnip/util/parser/ast_parser.lua:339: cannot represent snippet: contains circular dependencies                        
stack traceback:                                                                                                                                                            
        [C]: in function 'assert'                                                                                                                                           
        ...ker/start/LuaSnip/lua/luasnip/util/parser/ast_parser.lua:339: in function 'to_luasnip_nodes'                                                                     
        ...ck/packer/start/LuaSnip/lua/luasnip/util/parser/init.lua:51: in function 'parse_fn'                                                                              
        .../packer/start/LuaSnip/lua/luasnip/nodes/snippetProxy.lua:33: in function 'instantiate'                                                                           
        .../packer/start/LuaSnip/lua/luasnip/nodes/snippetProxy.lua:86: in function '__index'                                                                               
        .../packer/start/LuaSnip/lua/luasnip/nodes/snippetProxy.lua:99: in function 'copy'                                                                                  
        ...rvim/site/pack/packer/start/LuaSnip/lua/luasnip/init.lua:187: in function 'snip_expand'                                                                          
        ...e/pack/packer/start/cmp_luasnip/lua/cmp_luasnip/init.lua:143: in function 'execute'                                                                              
        ...arvim/site/pack/packer/start/nvim-cmp/lua/cmp/source.lua:378: in function 'execute'                                                                              
        ...narvim/site/pack/packer/start/nvim-cmp/lua/cmp/entry.lua:472: in function 'execute'                                                                              
        ...unarvim/site/pack/packer/start/nvim-cmp/lua/cmp/core.lua:467: in function <...unarvim/site/pack/packer/start/nvim-cmp/lua/cmp/core.lua:466>                      
        ...te/pack/packer/start/nvim-cmp/lua/cmp/utils/feedkeys.lua:47: in function <...te/pack/packer/start/nvim-cmp/lua/cmp/utils/feedkeys.lua:45>
```
Changed this to match the same string for PROGRAM-ID in other snippets.