### PR TITLE
Bugfix in copybook scanning that causes major performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "email": "stephen@gennard.net"
   },
   "engines": {
-    "vscode": "^1.150.0"
+    "vscode": "^1.105.0"
   },
   "extensionKind": [
     "workspace"

--- a/src/cobolsourcescanner.ts
+++ b/src/cobolsourcescanner.ts
@@ -470,26 +470,25 @@ export class COBOLCopybookToken {
 
             const possibleFileMod = features.getFileModTimeStamp(cpyFile);
             if (possibleFileMod === undefined) { 
+                if (refreshFromDisk && this.token !== undefined) {
+                    const timeTakenStart = features.performance_now();
+                    const newFileName = features.expandLogicalCopyBookToFilenameOrEmpty(this.token.tokenName, this.token.extraInformation, this.token.sourceHandler, configHandler);
+                    const totalTimeInMS = features.performance_now() - timeTakenStart;
+                    if (totalTimeInMS > configHandler.copybook_speed_limit) {
+                        this.refreshFromDisk = false;
+                        features.logMessage("Slow copybook change check dropped for " + cpyFile + " as it took " + totalTimeInMS.toFixed(2) + "ms");
+                        return false;
+                    }
+                    if (newFileName !== this.statementInformation.fileName) {
+                        return true;
+                    }
+                }
                 return false;
             }
 
             const fileFileMod = possibleFileMod as BigInt
             if (fileFileMod !== this.statementInformation.fileNameMod) {
                 return true;
-            }
-
-            if (refreshFromDisk && this.token !== undefined) {
-                const timeTakenStart = features.performance_now();
-                const newFileName = features.expandLogicalCopyBookToFilenameOrEmpty(this.token.tokenName, this.token.extraInformation, this.token.sourceHandler, configHandler);
-                const totalTimeInMS = features.performance_now() - timeTakenStart;
-                if (totalTimeInMS > configHandler.copybook_speed_limit) {
-                    this.refreshFromDisk = false;
-                    features.logMessage("Slow copybook change check dropped for " + cpyFile + " as it took " + totalTimeInMS.toFixed(2) + "ms");
-                    return false;
-                }
-                if (newFileName !== this.statementInformation.fileName) {
-                    return true;
-                }
             }
         }
 


### PR DESCRIPTION
Function hasCopybookChanged searches through the file system to find a copybook with a certain name AFTER a timestamp was already successfully retrieved from the previous file path. 
I believe this is unintended and should only happen when the file could not be found (in case the file would be moved to a different location for example.
This pull request fixes this bug.

(Also: for some reason the minimum requirement for vscode has been set to a version that doesn't exist yet. This was probably a typo.)