### PR TITLE
bugfix useCache

### DIFF
--- a/src/vscobolscanner.ts
+++ b/src/vscobolscanner.ts
@@ -126,6 +126,12 @@ export class VSCOBOLSourceScanner {
                         if (cbInfo.statementInformation !== undefined && avoidCopyBookCheck === false) {
                             useCache = cbInfo.hasCopybookChanged(cachedObject.externalFeatures, config) == false;
                         }
+                        if (!useCache) {
+                            break;
+                        }
+                    }
+                    if (!useCache) {
+                        break;
                     }
                 }
 


### PR DESCRIPTION
Variable useCache can be set to true again by a following copybook check after being set to false due to a changed copybook.
Breaking early fixes this bug.
Alternatively if you'd really not want to break early, you could write it like useCache &&= cbInfo.hasCopybookChanged.....