### PR TITLE
Don't check duplicate copybooks

### DIFF
--- a/src/vscobolscanner.ts
+++ b/src/vscobolscanner.ts
@@ -118,17 +118,13 @@ export class VSCOBOLSourceScanner {
             if (cachedObject !== undefined) {
                 let useCache = true;
                 for (const [, cbInfos] of cachedObject.copyBooksUsed) {
-                    for (const cbInfo of cbInfos) {
-                        if (!cbInfo.scanComplete) {
-                            continue;
-                        }
-
-                        if (cbInfo.statementInformation !== undefined && avoidCopyBookCheck === false) {
-                            useCache = cbInfo.hasCopybookChanged(cachedObject.externalFeatures, config) == false;
-                            if (!useCache) break; // exit inner loop early
-                        }
+                    if (cbInfos.length === 0) continue;
+                    const cbInfo = cbInfos[0]; // all members refer to the same copybook, so just check the first one
+                    if (!cbInfo.scanComplete) continue;
+                    if (cbInfo.statementInformation !== undefined && avoidCopyBookCheck === false) {
+                        useCache = cbInfo.hasCopybookChanged(cachedObject.externalFeatures, config) == false;
                     }
-                    if (!useCache) break; // exit outer loop early
+                    if (!useCache) break; // exit loop early
                 }
 
                 if (!useCache) {


### PR DESCRIPTION
Sorry for bothering you so much lately, I found another optimization regarding copybook cache invalidation.
The cbInfos array contains all occurences of a specific copybook. Since they all refer to the same file, only checking the first occurence should be enough.