### PR TITLE
Proposal: setting to disable copybook parsing in procedure division + copybook source/timestamp caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -688,6 +688,12 @@
           "default": false,
           "scope": "resource"
         },
+        "coboleditor.parse_copybooks_procedure_division": {
+          "type": "boolean",
+          "description": "Also scan procedure division when parse_copybooks_for_references is enabled",
+          "default": true,
+          "scope": "resource"
+        },
         "coboleditor.workspacefolders_order": {
           "type": "array",
           "description": "List of ordered workspace folders",
@@ -936,6 +942,15 @@
           "default": 6,
           "minimum": 2,
           "maximum": 24,
+          "scope": "window"
+        },
+        "coboleditor.in_memory_copybook_cache_size": {
+          "type": "number",
+          "title": "Size of internal copybook memory cache",
+          "description": "Size of internal memory cache for scanned copybooks",
+          "default": 10,
+          "minimum": 2,
+          "maximum": 30,
           "scope": "window"
         },
         "coboleditor.suggest_variables_when_context_is_unknown": {

--- a/src/cobolsourcescanner.ts
+++ b/src/cobolsourcescanner.ts
@@ -3242,7 +3242,14 @@ export class COBOLSourceScanner implements ICommentCallback, ICOBOLSourceScanner
             return false;
         }
         cbInfo.fileName = fileName;
-        cbInfo.fileNameMod = BigInt(0);
+        const cachedSource = this.sourceCache.get(fileName);
+        if (cachedSource?.fileModTimeStamp !== undefined) {
+            cbInfo.fileNameMod = cachedSource.fileModTimeStamp;
+        } else {
+            const _possibleLastModifiedTime = this.externalFeatures.getFileModTimeStamp(fileName);
+            cbInfo.fileNameMod = _possibleLastModifiedTime !== undefined ? _possibleLastModifiedTime : BigInt(0);
+            this.sourceCache.set(fileName, { lines: cachedSource?.lines, fileModTimeStamp: cbInfo.fileNameMod });
+        }
         if (this.copyBooksUsed.has(fileName) === false) {
             this.copyBooksUsed.set(fileName, [copybookToken]);
         } else {
@@ -3269,7 +3276,6 @@ export class COBOLSourceScanner implements ICommentCallback, ICOBOLSourceScanner
             if (this.parse_copybooks_for_references && fileName.length > 0 && (this.configHandler.parse_copybooks_procedure_division || state.inProcedureDivision === false)) {
                 cbInfo.fileName = fileName;
                 const qfile = new FileSourceHandler(this.configHandler, undefined, fileName, this.externalFeatures, this.sourceCache);
-                cbInfo.fileNameMod = qfile.documentVersionId !== undefined ? qfile.documentVersionId : BigInt(0);
                 const currentTopLevel = this.sourceReferences.topLevel;
                 this.sourceReferences.topLevel = false;
 

--- a/src/cobolsourcescanner.ts
+++ b/src/cobolsourcescanner.ts
@@ -3,7 +3,8 @@
 import { ISourceHandler, ICommentCallback, ISourceHandlerLite } from "./isourcehandler";
 import { cobolProcedureKeywordDictionary, cobolStorageKeywordDictionary, getCOBOLKeywordDictionary } from "./keywords/cobolKeywords";
 
-import { FileSourceHandler } from "./filesourcehandler";
+import { FileSourceHandler, SourceCacheLRU } from "./filesourcehandler";
+import { ISourceCache } from "./isourcehandler";
 import { COBOLFileAndColumnSymbol, COBOLFileSymbol, COBOLWorkspaceFile } from "./cobolglobalcache";
 
 import { ICOBOLSettings } from "./iconfiguration";
@@ -867,6 +868,7 @@ export class COBOLSourceScanner implements ICommentCallback, ICOBOLSourceScanner
     private implicitCount = 0;
 
     private readonly copyBookCache: ICopyBookCache;
+    private readonly sourceCache: ISourceCache;
 
     public static ScanUncached(sourceHandler: ISourceHandler,
         configHandler: ICOBOLSettings,
@@ -997,6 +999,7 @@ export class COBOLSourceScanner implements ICommentCallback, ICOBOLSourceScanner
                 break;
         }
         this.copyBookCache = externalFeatures.getCopyBookCache();
+        this.sourceCache = new SourceCacheLRU(configHandler.in_memory_copybook_cache_size);
 
         let sourceLooksLikeCOBOL = false;
         let prevToken: StreamTokens = StreamTokens.Blank;
@@ -2413,7 +2416,7 @@ export class COBOLSourceScanner implements ICommentCallback, ICOBOLSourceScanner
                             state.copybook_state.fileName = fileName;
                             const copybookToken = new COBOLCopybookToken(this.copyBookCache, copyToken, false, state.copybook_state);
                             this.copyBooksUsed.set(trimmedCopyBook, [copybookToken]);
-                            const qfile = new FileSourceHandler(this.configHandler, undefined, fileName, this.externalFeatures);
+                            const qfile = new FileSourceHandler(this.configHandler, undefined, fileName, this.externalFeatures, this.sourceCache);
                             const prevIgnoreInOutlineView = state.ignoreInOutlineView;
                             state.ignoreInOutlineView = true;
                             const currentTopLevel = this.sourceReferences.topLevel;
@@ -3239,8 +3242,7 @@ export class COBOLSourceScanner implements ICommentCallback, ICOBOLSourceScanner
             return false;
         }
         cbInfo.fileName = fileName;
-        const _possibleLastModifiedTime = this.externalFeatures.getFileModTimeStamp(fileName);
-        cbInfo.fileNameMod = _possibleLastModifiedTime !== undefined ? _possibleLastModifiedTime : BigInt(0);
+        cbInfo.fileNameMod = BigInt(0);
         if (this.copyBooksUsed.has(fileName) === false) {
             this.copyBooksUsed.set(fileName, [copybookToken]);
         } else {
@@ -3264,9 +3266,10 @@ export class COBOLSourceScanner implements ICommentCallback, ICOBOLSourceScanner
         }
 
         if (this.sourceReferences !== undefined) {
-            if (this.parse_copybooks_for_references && fileName.length > 0) {
+            if (this.parse_copybooks_for_references && fileName.length > 0 && (this.configHandler.parse_copybooks_procedure_division || state.inProcedureDivision === false)) {
                 cbInfo.fileName = fileName;
-                const qfile = new FileSourceHandler(this.configHandler, undefined, fileName, this.externalFeatures);
+                const qfile = new FileSourceHandler(this.configHandler, undefined, fileName, this.externalFeatures, this.sourceCache);
+                cbInfo.fileNameMod = qfile.documentVersionId !== undefined ? qfile.documentVersionId : BigInt(0);
                 const currentTopLevel = this.sourceReferences.topLevel;
                 this.sourceReferences.topLevel = false;
 
@@ -3320,7 +3323,7 @@ export class COBOLSourceScanner implements ICommentCallback, ICOBOLSourceScanner
                         if (this.copyBooksUsed.has(fileName) === false) {
                             this.copyBooksUsed.set(fileName, [COBOLCopybookToken.Null]);
 
-                            const qfile = new FileSourceHandler(this.configHandler, possRegExe, fileName, this.externalFeatures);
+                            const qfile = new FileSourceHandler(this.configHandler, possRegExe, fileName, this.externalFeatures, this.sourceCache);
                             const currentTopLevel = this.sourceReferences.topLevel;
                             this.sourceReferences.topLevel = false;
 

--- a/src/cobscanner.ts
+++ b/src/cobscanner.ts
@@ -154,7 +154,7 @@ export class Scanner {
             let fSendCount = 0;
             for (const file of scanData.Files) {
                 if (Utils.cacheUpdateRequired(file, features)) {
-                    const filesHandler = new FileSourceHandler(settings, undefined, file, features);
+                    const filesHandler = new FileSourceHandler(settings, undefined, file, features, undefined);
                     const config = new COBOLSettings();
                     config.parse_copybooks_for_references = scanData.parse_copybooks_for_references;
                     config.cache_metadata_verbose_messages = scanData.cache_metadata_verbose_messages;

--- a/src/filesourcehandler.ts
+++ b/src/filesourcehandler.ts
@@ -49,13 +49,13 @@ export class FileSourceHandler implements ISourceHandler, ISourceHandlerLite {
         this.settings = settings;
         this.shortFilename = this.findShortWorkspaceFilename(document, features, settings);
         const cachedFile = cache?.get(document);
-        this.documentVersionId = cachedFile === undefined ? fs.statSync(document, { bigint: true }).mtimeMs : cachedFile.documentVersionId;
+        this.documentVersionId = cachedFile?.fileModTimeStamp === undefined ? fs.statSync(document, { bigint: true }).mtimeMs : cachedFile.fileModTimeStamp;
         
         const startTime = features.performance_now();
         try {
             let line: string;
 
-            const linesRead = cachedFile === undefined ? fs.readFileSync(document).toString().split(/\r?\n/) : cachedFile.lines;
+            const linesRead = cachedFile?.lines === undefined ? fs.readFileSync(document).toString().split(/\r?\n/) : cachedFile.lines;
             if (this.lineRegExFilter !== undefined) {
                 for(line of linesRead) {
                     const l = line.toString();
@@ -70,7 +70,7 @@ export class FileSourceHandler implements ISourceHandler, ISourceHandlerLite {
                 this.lines = linesRead;
             }
             if (cache !== undefined) {
-                cache.set(document, { lines: linesRead, documentVersionId: this.documentVersionId });
+                cache.set(document, { lines: linesRead, fileModTimeStamp: this.documentVersionId });
             }
             features.logTimedMessage(features.performance_now() - startTime, " - Loading File " + document);
         }

--- a/src/filesourcehandler.ts
+++ b/src/filesourcehandler.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 
 import { ISourceHandler, ICommentCallback, ISourceHandlerLite, commentRange } from "./isourcehandler";
+import { ISourceCache, ISourceCacheEntry } from "./isourcehandler";
 import { ESourceFormat, IExternalFeatures } from "./externalfeatures";
 import { pathToFileURL } from "url";
 import path from "path";
@@ -30,7 +31,7 @@ export class FileSourceHandler implements ISourceHandler, ISourceHandlerLite {
     private readonly lineRegExFilter: RegExp | undefined;
     settings: ICOBOLSettings;
 
-    public constructor(settings: ICOBOLSettings, regEx: RegExp | undefined, document: string, features: IExternalFeatures) {
+    public constructor(settings: ICOBOLSettings, regEx: RegExp | undefined, document: string, features: IExternalFeatures, cache: ISourceCache | undefined) {
         this.lineRegExFilter = regEx;
         this.document = document;
         this.dumpNumbersInAreaA = false;
@@ -47,14 +48,14 @@ export class FileSourceHandler implements ISourceHandler, ISourceHandlerLite {
         this.commentsIndexInline = new Map<number, boolean>();
         this.settings = settings;
         this.shortFilename = this.findShortWorkspaceFilename(document, features, settings);
-        const docstat: fs.BigIntStats = fs.statSync(document, { bigint: true });
-
-        this.documentVersionId = docstat.mtimeMs;
+        const cachedFile = cache?.get(document);
+        this.documentVersionId = cachedFile === undefined ? fs.statSync(document, { bigint: true }).mtimeMs : cachedFile.documentVersionId;
+        
         const startTime = features.performance_now();
         try {
             let line: string;
 
-            const linesRead = fs.readFileSync(document).toString().split(/\r?\n/);
+            const linesRead = cachedFile === undefined ? fs.readFileSync(document).toString().split(/\r?\n/) : cachedFile.lines;
             if (this.lineRegExFilter !== undefined) {
                 for(line of linesRead) {
                     const l = line.toString();
@@ -67,6 +68,9 @@ export class FileSourceHandler implements ISourceHandler, ISourceHandlerLite {
                 }
             } else {
                 this.lines = linesRead;
+            }
+            if (cache !== undefined) {
+                cache.set(document, { lines: linesRead, documentVersionId: this.documentVersionId });
             }
             features.logTimedMessage(features.performance_now() - startTime, " - Loading File " + document);
         }
@@ -372,6 +376,49 @@ export class FileSourceHandler implements ISourceHandler, ISourceHandlerLite {
         }
 
         return fl;
+    }
+}
+
+export class SourceCacheLRU implements ISourceCache {
+    private readonly maxEntries: number;
+    private readonly map: Map<string, ISourceCacheEntry>;
+
+    constructor(maxEntries: number) {
+        this.maxEntries = Math.max(1, Math.floor(maxEntries));
+        this.map = new Map<string, ISourceCacheEntry>();
+    }
+
+    get(document: string): ISourceCacheEntry | undefined {
+        const entry = this.map.get(document);
+        if (entry === undefined) return undefined;
+
+        // refresh usage (move to newest)
+        this.map.delete(document);
+        this.map.set(document, entry);
+        return entry;
+    }
+
+    set(document: string, entry: ISourceCacheEntry): void {
+        if (this.map.has(document)) {
+            this.map.delete(document);
+        }
+
+        this.map.set(document, entry);
+
+        // evict oldest when over capacity
+        while (this.map.size > this.maxEntries) {
+            const oldestKey = this.map.keys().next().value as string;
+            if (oldestKey === undefined) break;
+            this.map.delete(oldestKey);
+        }
+    }
+
+    has(document: string): boolean {
+        return this.map.has(document);
+    }
+
+    delete(document: string): void {
+        this.map.delete(document);
     }
 }
 

--- a/src/iconfiguration.ts
+++ b/src/iconfiguration.ts
@@ -62,6 +62,7 @@ export interface ICOBOLSettings {
     // cache_metadata: CacheDirectoryStrategy;
     cache_metadata_inactivity_timeout: number;
     parse_copybooks_for_references: boolean;
+    parse_copybooks_procedure_division: boolean;
     workspacefolders_order: string[];
     linter_mark_as_information: boolean;
     linter_unused_sections: boolean;
@@ -118,6 +119,8 @@ export interface ICOBOLSettings {
     scan_time_limit: number;
 
     in_memory_cache_size: number;
+
+    in_memory_copybook_cache_size: number;
 
     suggest_variables_when_context_is_unknown: boolean;
 
@@ -230,6 +233,7 @@ export class COBOLSettings implements ICOBOLSettings {
     // cache_metadata: CacheDirectoryStrategy;
     cache_metadata_inactivity_timeout: number;
     parse_copybooks_for_references: boolean;
+    parse_copybooks_procedure_division: boolean;
     workspacefolders_order: string[];
     linter_mark_as_information: boolean;
     linter_unused_paragraphs: boolean;
@@ -286,6 +290,8 @@ export class COBOLSettings implements ICOBOLSettings {
     scan_time_limit: number;
 
     in_memory_cache_size: number;
+
+    in_memory_copybook_cache_size: number;
 
     suggest_variables_when_context_is_unknown: boolean;
 
@@ -393,6 +399,7 @@ export class COBOLSettings implements ICOBOLSettings {
         this.cache_metadata_inactivity_timeout = 5000;
         this.cache_metadata_verbose_messages = false;
         this.parse_copybooks_for_references = false;
+        this.parse_copybooks_procedure_division = true;
         this.workspacefolders_order = [];
         this.linter_mark_as_information = false;
         this.linter_unused_sections = true;
@@ -451,6 +458,7 @@ export class COBOLSettings implements ICOBOLSettings {
         this.scan_line_limit = 15000;
         this.scan_time_limit = 4000;
         this.in_memory_cache_size = 6;
+        this.in_memory_copybook_cache_size = 10;
         this.suggest_variables_when_context_is_unknown = true;
         this.hover_show_known_api = hoverApi.Short;
         this.enable_comment_tags = false;

--- a/src/isourcehandler.ts
+++ b/src/isourcehandler.ts
@@ -51,3 +51,15 @@ export interface ISourceHandler {
     getCommentAtLine(lineNumber: number):string;
     getText(startLine: number, startColumn:number, endLine: number, endColumn:number): string;
 }
+
+export interface ISourceCache {
+    get(document: string): ISourceCacheEntry | undefined;
+    set(document: string, entry: ISourceCacheEntry): void;
+    has(document: string): boolean;
+    delete(document: string): void;
+}
+
+export interface ISourceCacheEntry {
+    lines: string[];
+    documentVersionId: BigInt;
+}

--- a/src/isourcehandler.ts
+++ b/src/isourcehandler.ts
@@ -60,6 +60,6 @@ export interface ISourceCache {
 }
 
 export interface ISourceCacheEntry {
-    lines: string[];
-    documentVersionId: BigInt;
+    lines: string[] | undefined;
+    fileModTimeStamp: BigInt | undefined;
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -17,7 +17,7 @@ suite("Core Extension Test Suite", () => {
 	const settings = new COBOLSettings();
 
 	test("Read file [basic] (test.cbl)", () => {
-		const f = new FileSourceHandler(settings, undefined, path.join(baseForSource,"test.cbl"), features);
+		const f = new FileSourceHandler(settings, undefined, path.join(baseForSource,"test.cbl"), features, undefined);
 		if (f.lines.length < 10) {
 			assert.fail("test.cbl should have > 10 lines");
 		}
@@ -26,7 +26,7 @@ suite("Core Extension Test Suite", () => {
 	});
 
 	test("Parse file for constants/paragraphs/sections (test.cbl)", () => {
-		const f = new FileSourceHandler(settings, undefined, path.join(baseForSource,"test.cbl"), features);
+		const f = new FileSourceHandler(settings, undefined, path.join(baseForSource,"test.cbl"), features, undefined);
 		if (f.lines.length < 10) {
 			assert.fail("test.cbl should have > 10 lines");
 		}

--- a/src/vsconfiguration.ts
+++ b/src/vsconfiguration.ts
@@ -148,6 +148,7 @@ export class VSCOBOLConfiguration {
         settings.cache_metadata_inactivity_timeout = editorHelper.getNumber("cache_metadata_inactivity_timeout", 5000);
         settings.cache_metadata_verbose_messages = editorHelper.getBoolean("cache_metadata_verbose_messages", false);
         settings.parse_copybooks_for_references = editorHelper.getBoolean("parse_copybooks_for_references", false);
+        settings.parse_copybooks_procedure_division = editorHelper.getBoolean("parse_copybooks_procedure_division", true);
         settings.workspacefolders_order = editorHelper.getWorkspacefolders_order();
         settings.linter_unused_sections = editorHelper.getBoolean("linter_unused_sections", true);
         settings.linter_unused_paragraphs = editorHelper.getBoolean("linter_unused_paragraphs", true);
@@ -211,6 +212,8 @@ export class VSCOBOLConfiguration {
         settings.scan_time_limit = editorConfig.get<number>("scan_time_limit", settings.scan_time_limit);
 
         settings.in_memory_cache_size = editorConfig.get<number>("in_memory_cache_size", settings.in_memory_cache_size);
+
+        settings.in_memory_copybook_cache_size = editorConfig.get<number>("in_memory_copybook_cache_size", settings.in_memory_copybook_cache_size);
 
         settings.suggest_variables_when_context_is_unknown = editorConfig.get<boolean>("suggest_variables_when_context_is_unknown", settings.suggest_variables_when_context_is_unknown);
 


### PR DESCRIPTION
In practice it is usually more helpful to parse the copybooks in the data division compared to anywhere else in the program.
Since the procedure division usually contains the most copybooks, it is a big contributor to lag, while sometimes not being that useful.
A setting to disable the parsing of these copybooks could help. 
NOTE: this does not break ctrl+click on the copy statement.

Additionally this PR contains a proposal to cache the copybook source lines + timestamp to reduce file IO in the FileSourceHandler. 
I am aware that this code is not perfect, but it is a great starting point and I am open for feedback.
For example: there is probably a better place to call the constructor of the cache and it could probably be shared in a wider context (since it only uses the exact file path as a key and the cache can't become too big, due to the fact that it is an LRU cache).
